### PR TITLE
Adds return statement to the function HaralickDiffVariance

### DIFF
--- a/src/haralick_feat.cc
+++ b/src/haralick_feat.cc
@@ -131,6 +131,7 @@ double HaralickDiffVariance(Mat cooc, vector<double> diff) {
     double diffent = HaralickDiffEntropy(cooc, diff);
     for (int i = 0; i < diff.size(); i++)
         diffvar += (i - diffent) * (i - diffent) * diff[i];
+    return diffvar;
 }
 
 /*Features from Probsum*/


### PR DESCRIPTION
The function is supposed to return the variable `diffvar`.
The return statement was missing because of which some compilers may return a garbage value, and hence the nature of the function becomes ambiguous.
The return statement has been added at the relevant position.